### PR TITLE
purge warnings

### DIFF
--- a/hipo4/bank.h
+++ b/hipo4/bank.h
@@ -191,6 +191,13 @@ namespace hipo {
         void    putDouble( const char *name, int index, double value);
         void    putLong(   const char *name, int index, int64_t value);
 
+ 	void    putInt(int item, int index, int32_t value);
+        void    putShort(int item, int index, int16_t value);
+        void    putByte(int item, int index, int8_t value);
+        void    putFloat(int item, int index, float value);
+        void    putDouble(int item, int index, double value);
+        void    putLong(int item, int index, int64_t value);
+     
         void    show() override;
         void    reset();
         //virtual  void notify(){ };
@@ -325,6 +332,36 @@ namespace hipo {
       }
       return 0;
     }
-
+  inline void    bank::putInt(int item, int index, int32_t value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      putIntAt(offset,value);
+    }
+    inline void    bank::putShort(int item, int index, int16_t value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      putShortAt(offset,value);
+    }
+    inline void    bank::putByte(int item, int index, int8_t value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      putByteAt(offset,value);
+    }
+    inline  void    bank::putFloat(int item, int index, float value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      //printf("---- put float %f at position = %d\n",value,offset);
+      putFloatAt(offset,value);
+    }
+    inline void    bank::putDouble(int item, int index, double value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      putDoubleAt(offset,value);
+    }
+    inline void    bank::putLong(int item, int index, int64_t value){
+      int type = bankSchema.getEntryType(item);
+      int offset = bankSchema.getOffset(item, index, bankRows);
+      putLongAt(offset,value);
+    }
 }
 #endif /* BANK_H */

--- a/hipo4/reader.h
+++ b/hipo4/reader.h
@@ -93,27 +93,27 @@
 namespace hipo {
 
   typedef struct {
-    int  uniqueid;
-    int  filenumber;
-    int  headerLength; // in words (usually 14)
-    int  recordCount;
-    int  indexArrayLength; // in bytes
-    int  bitInfo;
-    int  version;
-    int  userHeaderLength;
-    int  magicNumber;
-    long userRegister;
-    long trailerPosition;
-    long firstRecordPosition;
+    int  uniqueid{};
+    int  filenumber{};
+    int  headerLength{}; // in words (usually 14)
+    int  recordCount{};
+    int  indexArrayLength{}; // in bytes
+    int  bitInfo{};
+    int  version{};
+    int  userHeaderLength{};
+    int  magicNumber{};
+    long userRegister{};
+    long trailerPosition{};
+    long firstRecordPosition{};
   } fileHeader_t;
 
 
   typedef struct {
-      long recordPosition;
-      int  recordLength;
-      int  recordEntries;
-      long userWordOne;
-      long userWordTwo;
+      long recordPosition{};
+      int  recordLength{};
+      int  recordEntries{};
+      long userWordOne{};
+      long userWordTwo{};
   } recordInfo_t;
   /**
 * READER index class is used to construct entire events

--- a/hipo4/reader.h
+++ b/hipo4/reader.h
@@ -236,10 +236,10 @@ namespace hipo {
         void  read(hipo::event &dataevent);
         void  printWarning();
 	//dglazier
- 	      int getNRecords() const {return readerEventIndex.getNRecords()-1;}
-	      bool  nextInRecord();
-	      bool loadRecord(int irec);
-	      int  getEntries(){return readerEventIndex.getMaxEvents();}
-      };
+	int getNRecords() const {return readerEventIndex.getNRecords()-1;}
+	bool  nextInRecord();
+	bool loadRecord(int irec);
+	int  getEntries(){return readerEventIndex.getMaxEvents();}
+  };
 }
 #endif /* HIPOREADER_H */

--- a/hipo4/record.h
+++ b/hipo4/record.h
@@ -28,27 +28,27 @@
 namespace hipo {
 
     typedef struct {
-        int signatureString; // 1) identifier string is HREC (int = 0x43455248
-        int recordLength; // 2) TOTAL Length of the RECORD, includes INDEX array
-        int recordDataLength; // 3) Length of the DATA uncompressed
-        int recordDataLengthCompressed; // 4) compressed length of the DATA buffer
-        int numberOfEvents ; // 5) number of event, data buckets in DATA buffer
-        int headerLength ; // 6) Length of the buffer represengin HEADER for the record
-        int indexDataLength ; // 7) Length of the index buffer (in bytes)
-        int userHeaderLength; // user header length in bytes
-        int userHeaderLengthPadding; // the padding added to user header Length
-        int bitInfo;
-        int compressionType;
-        int compressedLengthPadding;
-        int dataEndianness;
+      int signatureString{}; // 1) identifier string is HREC (int = 0x43455248
+      int recordLength{}; // 2) TOTAL Length of the RECORD, includes INDEX array
+      int recordDataLength{}; // 3) Length of the DATA uncompressed
+      int recordDataLengthCompressed{}; // 4) compressed length of the DATA buffer
+      int numberOfEvents{} ; // 5) number of event, data buckets in DATA buffer
+      int headerLength{} ; // 6) Length of the buffer represengin HEADER for the record
+      int indexDataLength{} ; // 7) Length of the index buffer (in bytes)
+      int userHeaderLength{}; // user header length in bytes
+      int userHeaderLengthPadding{}; // the padding added to user header Length
+      int bitInfo{};
+      int compressionType{};
+      int compressedLengthPadding{};
+      int dataEndianness{};
     } recordHeader_t;
 
     class data {
       private:
-        const char  *data_ptr;
-        int          data_size;
-        int          data_endianness{};
-        int          data_offset{};
+      const char  *data_ptr{};
+      int          data_size{};
+      int          data_endianness{};
+      int          data_offset{};
 
       public:
         data(){ data_ptr = nullptr; data_size = 0;}


### PR DESCRIPTION
On some compilers i.e. on ifarm. Warnings are output for not having struct data members initialised. 
Here I just explicitly initialise the data members :

  typedef struct {
      int signatureString{}; // 1) identifier string is HREC (int = 0x43455248
      int recordLength{}; // 2) TOTAL Length of the RECORD, includes INDEX array
      int recordDataLength{}; // 3) Length of the DATA uncompressed
      int recordDataLengthCompressed{}; // 4) compressed length of the DATA buffer
      int numberOfEvents{} ; // 5) number of event, data buckets in DATA buffer
      int headerLength{} ; // 6) Length of the buffer represengin HEADER for the record
      int indexDataLength{} ; // 7) Length of the index buffer (in bytes)
      int userHeaderLength{}; // user header length in bytes
      int userHeaderLengthPadding{}; // the padding added to user header Length
      int bitInfo{};
      int compressionType{};
      int compressedLengthPadding{};
      int dataEndianness{};
    } recordHeader_t;