### PR TITLE
add extra functions to allow writing with tags

### DIFF
--- a/hipo4/recordbuilder.cpp
+++ b/hipo4/recordbuilder.cpp
@@ -101,6 +101,14 @@ namespace hipo {
     return wTwo;
   }
 
+  void recordbuilder::setUserWordOne(long userWordOne){
+    bufferUserWordOne = userWordOne;
+  }
+
+  void recordbuilder::setUserWordTwo(long userWordTwo){
+    bufferUserWordTwo = userWordTwo;
+  } 
+
   void recordbuilder::build(){
       int  indexSize = bufferIndexEntries*4;
       int eventsSize = bufferEventsPosition;
@@ -125,8 +133,8 @@ namespace hipo {
       hipo::utils::writeInt(&bufferRecord[0], 32, eventsSize); // (9) magic word
       int compressionWord = (1<<28)|(0x0FFFFFFF&compressedSizeToWriteWords);
       hipo::utils::writeInt(&bufferRecord[0], 36, compressionWord);
-      hipo::utils::writeLong(&bufferRecord[0], 40, 0);
-      hipo::utils::writeLong(&bufferRecord[0], 48, 0);
+      hipo::utils::writeLong(&bufferRecord[0], 40, bufferUserWordOne);
+      hipo::utils::writeLong(&bufferRecord[0], 48, bufferUserWordTwo);
       //printf("record::build uncompressed size = %8d, compressed size = %8d, rounding = %4d , compressed FULL = %6d, record size = %6d, version = %X, size = %5X\n",
       //      uncompressedSize,compressedSize, rounding,compressedSizeToWrite, recordLength*4,versionWord,compressionWord);
   }

--- a/hipo4/recordbuilder.h
+++ b/hipo4/recordbuilder.h
@@ -40,6 +40,8 @@ namespace hipo {
 
         int                bufferIndexEntries;
         int                bufferEventsPosition;
+	long               bufferUserWordOne = 0;
+	long               bufferUserWordTwo = 0;
 
         int                compressRecord(int src_size);
         int                getRecordLengthRounding(int bufferSize);
@@ -55,6 +57,8 @@ namespace hipo {
 
         long getUserWordOne();
         long getUserWordTwo();
+	void setUserWordOne(long userWordOne);
+	void setUserWordTwo(long userWordTwo);
 
         int  getRecordSize();
         int  getEntries();

--- a/hipo4/writer.cpp
+++ b/hipo4/writer.cpp
@@ -181,4 +181,25 @@ void writer::close(){
   outputStream.close();
 }
 
+/***
+* Function to change the record builder user word one
+*/
+void writer::setUserIntegerOne(long userIntOne){
+  recordBuilder.setUserWordOne(userIntOne);
+}
+
+/***
+*Function to change the record builder user word two
+*/
+void writer::setUserIntegerTwo(long userIntTwo){
+  recordBuilder.setUserWordTwo(userIntTwo);
+}
+
+/***
+*Function to write buffer.
+*/
+void writer::flush(){
+  writeRecord(recordBuilder);
+}
+
 }

--- a/hipo4/writer.h
+++ b/hipo4/writer.h
@@ -164,6 +164,9 @@ class writer {
      void showSummary();
      void addDictionary(hipo::dictionary &dict);
      hipo::dictionary &getDictionary(){ return writerDictionary;}
+     void setUserIntegerOne(long userIntOne);
+     void setUserIntegerTwo(long userIntTwo);
+     void flush();
 };
 
 };


### PR DESCRIPTION
These modifications were done by Richard Tyson, Glasgow.

These changes are:

recordbuilder: Added setter functions for user integers one and two and function declarations to the header file. Changed "build" function to write the correct user words instead of always 0.


writer: Added setter functions for the user words one and two. Added "flush" function to write the record that is kept in the record builder's buffer. This was necessary to make sure that a given user word is written with the correct set of events.