### PR TITLE
stop rare crash, add verbose

### DIFF
--- a/hipo4/reader.cpp
+++ b/hipo4/reader.cpp
@@ -133,17 +133,15 @@ namespace hipo {
     header.version = word_8&0x000000FF;
     header.bitInfo = (word_8>>8)&0x00FFFFFF;
     header.firstRecordPosition = 4*header.headerLength + header.userHeaderLength;
-
-    //printf("hipo::reader >> version %3d, data offset = %5lu, trailer at %lu\n",
-    //    header.version,header.firstRecordPosition,header.trailerPosition);
-
-    //printf("----------------------------------------\n");
-    //printf("**** reader:: header version   : %d \n",header.version);
-    //printf("**** reader:: header length    : %d \n",header.headerLength*4);
-    //printf("**** reader:: first record pos : %lu\n",header.firstRecordPosition);
-    //printf("**** reader:: trailer position : %lu\n",header.trailerPosition);
-    //printf("**** reader:: file size        : %lu\n",inputStreamSize);
-    //printf("----------------------------------------\n");
+    if(_verbose){
+      printf("----------------------------------------\n");
+      printf("**** reader:: header version   : %d \n",header.version);
+      printf("**** reader:: header length    : %d \n",header.headerLength*4);
+      printf("**** reader:: first record pos : %lu\n",header.firstRecordPosition);
+      printf("**** reader:: trailer position : %lu\n",header.trailerPosition);
+      printf("**** reader:: file size        : %lu\n",inputStreamSize);
+      printf("----------------------------------------\n");
+    }
     //int *signature = reinterpret_cast<int *>(&headerBuffer[0]);
     //printf("signature = %X\n",(unsigned int) *signature);
     //std::cout << "signature = " << std::ios::hex << (*signature) << '\n';
@@ -159,13 +157,18 @@ namespace hipo {
 void  reader::readIndex(){
 
     inputRecord.readRecord(inputStream,header.trailerPosition,0);
-    //printf("*** reader:: trailer record event count : %d\n",inputRecord.getEventCount());
+    if(_verbose)printf("*** reader:: trailer record event count : %d\n",inputRecord.getEventCount());
+
+    //a catch for broken files
+    //can use hiporeader.getNRecords() to see if succesfull (=-1 if not)
+    if(inputRecord.getEventCount()==0) return;//dglazier
+
     hipo::event event;
     inputRecord.readHipoEvent(event,0);
-    event.show();
+    if(_verbose)event.show();
     hipo::structure base;
     event.getStructure(base,32111,1);
-    base.show();
+    if(_verbose)base.show();
     readerEventIndex.clear();
     int rows = base.getSize()/32;
 
@@ -192,7 +195,7 @@ void  reader::readIndex(){
     }
     readerEventIndex.rewind();
     //printf("**** reader:: header version   : %d \n",readerEventIndex.getMaxEvents());
-    //printf("**** reader::  # of events     : %d \n",readerEventIndex.getMaxEvents());
+    if(_verbose)printf("**** reader::  # of events     : %d \n",readerEventIndex.getMaxEvents());
 }
 /**
  * Checks if there are more events in the file to advance to.

--- a/hipo4/reader.h
+++ b/hipo4/reader.h
@@ -209,7 +209,8 @@ namespace hipo {
         hipo::record       inputRecord;
         hipo::readerIndex  readerEventIndex;
         std::vector<long>  tagsToRead;
-
+	short _verbose = {0} ;
+	
         void  readHeader();
         void  readIndex();
     public:
@@ -226,17 +227,17 @@ namespace hipo {
 
         void  open(const char *filename);
         void  setTags(int tag){ tagsToRead.push_back(tag);}
-	      void  setTags(std::vector<long> tags){ tagsToRead=std::move(tags);}
-
-
-	      bool  hasNext();
+	void  setTags(std::vector<long> tags){ tagsToRead=std::move(tags);}
+	void  setVerbose(short level=1){_verbose=level;}
+	      
+	bool  hasNext();
         bool  next();
         bool  gotoEvent(int eventNumber);
         bool  gotoRecord(int irec);
         bool  next(hipo::event &dataevent);
         void  read(hipo::event &dataevent);
         void  printWarning();
-	//dglazier
+
 	int getNRecords() const {return readerEventIndex.getNRecords()-1;}
 	bool  nextInRecord();
 	bool loadRecord(int irec);


### PR DESCRIPTION
add verbose option, prevent reader proceeding when event count is zero, preventing crash. This crash occurred when analysing order 10k simulated files. One file was not able to be read an caused crash. I found the follwing fix stopped the crash and allowed to continue analysing the chain of files,

    //a catch for broken files
    //can use hiporeader.getNRecords() to see if succesful (=-1 if not)
    if(inputRecord.getEventCount()==0) return;//dglazier

Verbose output can be produced with 
reader::setVerbose()
