### PR TITLE
Fix error in dataframe CMakeFiles.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ endif()
 add_compile_definitions(__LZ4__)
 include_directories(${LZ4_INCLUDE_DIRS})
 
+set(DATAFRAME_IN_MAIN TRUE)
 add_subdirectory(extensions/dataframes)
 
 set(HIPO_SOURCE_FILES

--- a/extensions/dataframes/CMakeLists.txt
+++ b/extensions/dataframes/CMakeLists.txt
@@ -46,13 +46,12 @@ if(APPLE)
 
 endif(APPLE)
 
-find_package(hipo4 REQUIRED)
-if( ${hipo4_FOUND})
-    message(STATUS "Hipo4 found. ")
-else()
-    message(STATUS "You will never see this message, becaus if not found, find_package should have aborted.")
+if(NOT DATAFRAME_IN_MAIN)
+    find_package(hipo4 REQUIRED)
+    if( ${hipo4_FOUND})
+        message(STATUS "Hipo4 found. ")
+    endif()
 endif()
-
 
 find_package(ROOT COMPONENTS Core RootDataFrame ROOTVecOps)
 if(NOT ROOT_FOUND)


### PR DESCRIPTION
The CMakeFiles.txt was for a standalone compile, which would break the compile when run as a sub task from hipo4. 