### PR TITLE
support default $OSTYPE variable on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #
 SHAREDEXT=so
 
-ifeq ($(OSTYPE),darwin)
+ifneq (,$(findstring darwin,$(OSTYPE)))
   SHAREDEXT=dylib
 endif
 


### PR DESCRIPTION
just check whether it contains "darwin"