### PR TITLE
fix: enable `C` language for LZ4 `check_c_source_runs`

### DIFF
--- a/cmake/LZ4Config.cmake
+++ b/cmake/LZ4Config.cmake
@@ -8,6 +8,7 @@ if (LZ4_LIBRARY)
     include(CheckCSourceRuns)
     set(CMAKE_REQUIRED_INCLUDES ${LZ4_INCLUDE_DIR})
     set(CMAKE_REQUIRED_LIBRARIES ${LZ4_LIBRARY})
+    enable_language(C)
     check_c_source_runs("
 #include <lz4.h>
 int main() {


### PR DESCRIPTION
It seems that `check_c_source_runs` needs the `C` language to be enabled, otherwise I get the following error from `meson`'s dependency resolution:
```
CMake Error at /usr/share/cmake/Modules/Internal/CheckSourceRuns.cmake:41 (message):
  check_source_runs: C: needs to be enabled before use.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/CheckCSourceRuns.cmake:52 (cmake_check_source_runs)
  /home/dilks/j/install/lib/cmake/hipo4/LZ4Config.cmake:12 (check_c_source_runs)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /home/dilks/j/install/lib/cmake/hipo4/hipo4Config.cmake:31 (find_dependency)
  CMakeLists.txt:20 (find_package)
```
This PR resolves this by enabling `C`.

Tested with:
- `cmake` version 3.27.7
- `lz4` version 1:1.9.4-1 (system installation)

Error produced by `meson` version 1.2.3, with the following usage to find `hipo4` (basically this calls `find_package(hipo4)` and a bit more):
```meson
hipo_dep = dependency('hipo4', method: 'cmake')
```
I don't see the same issue when calling `find_package(hipo4)` with `cmake`, so maybe `meson` is doing some extra stuff... 