### PR TITLE
feat: `get` and `put` templates for `hipo::bank`

### DIFF
--- a/hipo4/bank.h
+++ b/hipo4/bank.h
@@ -242,6 +242,20 @@ namespace hipo {
         float  getFloat(  int item, int index) const noexcept;
         double getDouble( int item, int index) const noexcept;
         long   getLong(   int item, int index) const noexcept;
+        template<typename T = double> T get(int item, int index) const noexcept {
+          auto type = bankSchema.getEntryType(item);
+          switch(type) {
+            case kByte:   return getByte(item, index);
+            case kShort:  return getShort(item, index);
+            case kInt:    return getInt(item, index);
+            case kFloat:  return getFloat(item, index);
+            case kDouble: return getDouble(item, index);
+            case kLong:   return getLong(item, index);
+            default:
+              printf("---> error(get) : unknown type for [%s] type = %d\n", bankSchema.getEntryName(item).c_str(), type);
+          }
+          return 0;
+        }
 
         int    getInt(    const char *name, int index) const noexcept;
         int    getShort(  const char *name, int index) const noexcept;
@@ -249,6 +263,9 @@ namespace hipo {
         float  getFloat(  const char *name, int index) const noexcept;
         double getDouble( const char *name, int index) const noexcept;
         long   getLong(   const char *name, int index) const noexcept;
+        template<typename T = double> T get(const char *name, int index) const noexcept {
+          return get<T>(bankSchema.getEntryOrder(name), index);
+        }
 
         void    putInt(    const char *name, int index, int32_t value);
         void    putShort(  const char *name, int index, int16_t value);
@@ -256,6 +273,9 @@ namespace hipo {
         void    putFloat(  const char *name, int index, float value);
         void    putDouble( const char *name, int index, double value);
         void    putLong(   const char *name, int index, int64_t value);
+        template<typename T> void put(const char *name, int index, T value) {
+          put(bankSchema.getEntryOrder(name), index, value);
+        }
 
  	void    putInt(int item, int index, int32_t value);
         void    putShort(int item, int index, int16_t value);
@@ -263,6 +283,19 @@ namespace hipo {
         void    putFloat(int item, int index, float value);
         void    putDouble(int item, int index, double value);
         void    putLong(int item, int index, int64_t value);
+        template<typename T> void put(int item, int index, T value) {
+          auto type = bankSchema.getEntryType(item);
+          switch(type) {
+            case kByte:   putByte(item,   index, static_cast<int8_t>(value));  break;
+            case kShort:  putShort(item,  index, static_cast<int16_t>(value)); break;
+            case kInt:    putInt(item,    index, static_cast<int32_t>(value)); break;
+            case kFloat:  putFloat(item,  index, static_cast<float>(value));   break;
+            case kDouble: putDouble(item, index, static_cast<double>(value));  break;
+            case kLong:   putLong(item,   index, static_cast<int64_t>(value)); break;
+            default:
+              printf("---> error(put) : unknown type for [%s] type = %d\n", bankSchema.getEntryName(item).c_str(), type);
+          }
+        }
      
         void    show() override;
         void    reset();

--- a/hipo4/dictionary.cpp
+++ b/hipo4/dictionary.cpp
@@ -32,30 +32,30 @@ namespace hipo {
 
   int   schema::getTypeByString(std::string &typeName){
       if(typeName=="B"){
-        return 1;
+        return kByte;
       } else if(typeName=="S") {
-        return 2;
+        return kShort;
       } else if(typeName=="I") {
-        return 3;
+        return kInt;
       } else if(typeName=="F") {
-        return 4;
+        return kFloat;
       } else if(typeName=="D") {
-        return 5;
+        return kDouble;
       } else if(typeName=="L") {
-        return 8;
+        return kLong;
       }
       return -1;
   }
 
   int  schema::getTypeSize(int id){
     switch(id){
-      case 1: return 1;
-      case 2: return 2;
-      case 3: return 4;
-      case 4: return 4;
-      case 5: return 8;
-      case 8: return 8;
-      default: return 0;
+      case kByte:   return 1;
+      case kShort:  return 2;
+      case kInt:    return 4;
+      case kFloat:  return 4;
+      case kDouble: return 8;
+      case kLong:   return 8;
+      default:      return 0;
     }
     return 0;
   }

--- a/hipo4/dictionary.h
+++ b/hipo4/dictionary.h
@@ -33,6 +33,16 @@ namespace hipo {
     int          offset{};
   } schemaEntry_t;
 
+  enum Type {
+    kByte   = 1,
+    kShort  = 2,
+    kInt    = 3,
+    kFloat  = 4,
+    kDouble = 5,
+    kLong   = 8
+  };
+
+
 class schema {
   private:
 
@@ -99,6 +109,14 @@ class schema {
     int   getEntryType(int item) const noexcept {
       return schemaEntries[item].typeId;
     }
+    int   getEntryType(const char *name) const noexcept {
+      auto item = getEntryOrder(name);
+      if(item >= 0)
+        return schemaEntries[item].typeId;
+      else
+        return -1;
+    }
+
     std::string getEntryName(int item)  const noexcept { return schemaEntries[item].name;}
     int   getEntries() const noexcept { return schemaEntries.size();}
     void  show();
@@ -121,7 +139,7 @@ class schema {
    
    if(warningCount>0 ) { warningCount--; std::cout<<"Warning , hipo::schema getEntryOrder(const char *name) item :" <<name<<" not found, for bank "<<schemaName<<" data for this item is not valid "<<std::endl;
    }
-   return 0;
+   return -1;
  }
  
  


### PR DESCRIPTION
Add template `get` and `put` methods to `hipo::bank` so that callers may use type inference, _e.g._,
```cpp
auto pid = rec_particle_bank.get("pid",0);
```
```cpp
int new_pid = 888;
new_rec_particle_bank.put("pid", 0, new_pid);  // will be casted to the correct type within
```

Additionally, 
- use an enumerator for the types
- add `getEntryType(const char *name)` to `hipo::schema`
- fix the default (on error) return value of `schema::getEntryOrder`
- for `hipo::bank::get(...)` callers to compile, a default type (`double`) is specified (since the real type can only be deduced at runtime)