### PR TITLE
fix: integer signedness warning

### DIFF
--- a/hipo4/reader.h
+++ b/hipo4/reader.h
@@ -232,7 +232,7 @@ namespace hipo {
       reader(const char *file){ open(file);}
       
       reader(const char *file, std::vector<int> tags){
-          for(int t = 0; t < tags.size(); t++) setTags(tags[t]);
+         for(auto tag : tags) setTags(tag);
          open(file);
       }
 


### PR DESCRIPTION
Fixes the following warning (when building with `-Wsign-compare`):
```
/home/dilks/j/install/include/hipo4/reader.h: In constructor ‘hipo::reader::reader(const char*, std::vector<int>)’:
/home/dilks/j/install/include/hipo4/reader.h:235:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  235 |           for(int t = 0; t < tags.size(); t++) setTags(tags[t]);
      |                          ~~^~~~~~~~~~~~~
```