### PR TITLE
fix: sign warnings in `bank.h`

### DIFF
--- a/hipo4/bank.h
+++ b/hipo4/bank.h
@@ -311,7 +311,7 @@ namespace hipo {
     private:
       hipo::bank  &ib;
       std::vector<int> rows;
-      int current_index;
+      decltype(rows)::size_type current_index;
     public:
       iterator();
       iterator(hipo::bank &b, std::vector<int> index) : ib(b) {
@@ -333,7 +333,7 @@ namespace hipo {
       }
       bool end(){return current_index>=rows.size();}
       int  index(){ return rows[current_index];}
-      void show(){ for(int i = 0; i < rows.size(); i++) printf("%5d ",rows[i]); printf("\n");}
+      void show(){ for(const auto& row : rows) printf("%5d ",row); printf("\n");}
       
       static hipo::iterator link(hipo::bank &b, int row, int column);
       static hipo::iterator reduce(std::function<double(hipo::bank&, int)> func, hipo::bank& bank);


### PR DESCRIPTION
Fixes some sign warnings in `bank.h`. There are actually a lot of these warnings, if you build with `-Wall`... but for now these are the only ones that `iguana` complains about.