### PR TITLE
build: generate `pkg-config` file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,3 +168,9 @@ configure_package_config_file( cmake/hipo4Config.cmake.in
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hipo4Config.cmake ${CMAKE_CURRENT_BINARY_DIR}/hipo4ConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/hipo4)
+
+configure_file(${PROJECT_SOURCE_DIR}/cmake/hipo4.pc.in
+               ${PROJECT_BINARY_DIR}/hipo4.pc
+               @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/hipo4.pc
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)

--- a/cmake/hipo4.pc.in
+++ b/cmake/hipo4.pc.in
@@ -1,0 +1,9 @@
+prefix=${pcfiledir}/../..
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: hipo4
+Description: High Performance Output data format for experimental physics
+Version: @HIPO_VERSION@
+Libs: -L${libdir} -lhipo4
+Cflags: -I${includedir}


### PR DESCRIPTION
[pkg-config](https://en.wikipedia.org/wiki/Pkg-config) is one of the standard tools to help with dependency resolution; in my experience it's more generally usable than `cmake` package configurations, especially by non-`cmake` consumers.

Consumers which use `cmake` may load `hipo4` using
```cmake
find_package(PkgConfig REQUIRED)
pkg_check_modules(hipo4 REQUIRED IMPORTED_TARGET hipo4)
```
which will create the imported target `PkgConfig::hipo4` that can be used as, for example,
```cmake
target_link_libraries(ConsumerLibrary PUBLIC PkgConfig::hipo4)
```
This usage assumes the `hipo4` installation is found within `CMAKE_PREFIX_PATH` and `PKG_CONFIG_USE_CMAKE_PREFIX_PATH` has not been disabled (it's enabled by default, otherwise `PKG_CONFIG_PATH` is needed, see below).

More generally, one can get the relevant compiler flags (`-I`, `-L`, `-l`) for `hipo4` via:
```bash
pkg-config --cflags hipo4
pkg-config --libs hipo4
```
This assumes the directory with the generated `.pc` file is in `$PKG_CONFIG_PATH`.