### PR TITLE
feat: add CI build tests on Linux and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: HIPO CI
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+    tags: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: |
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install
+          cmake --build build -j2
+          cmake --install build
+      - run: brew install tree
+        if: ${{ matrix.runner == 'macos-latest' }}
+      - run: tree install


### PR DESCRIPTION
Add build tests running `cmake`.

CI jobs will fail until https://github.com/gavalian/hipo/pull/40 is merged.