### PR TITLE
fix: return nonzero exit code for failures

### DIFF
--- a/examples/benchmarks/ana_benchmark.cc
+++ b/examples/benchmarks/ana_benchmark.cc
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/builder.cc
+++ b/examples/builder.cc
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/histograms.cc
+++ b/examples/histograms.cc
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
     //sprintf(outputFile,"%s",argv[2]);
   } else {
     std::cout << " *** please provide a file name..." << std::endl;
-    exit(0);
+    exit(1);
   }
 
   //example3(inputFile);

--- a/examples/readEvents.cc
+++ b/examples/readEvents.cc
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/readFile.cc
+++ b/examples/readFile.cc
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/readFileDebug.cc
+++ b/examples/readFileDebug.cc
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
 

--- a/examples/readFileTags.cc
+++ b/examples/readFileTags.cc
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/readFusion.cc
+++ b/examples/readFusion.cc
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::fusion  fusion;

--- a/examples/readHist.cc
+++ b/examples/readHist.cc
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/readJson.cc
+++ b/examples/readJson.cc
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/root/benchmark.cc
+++ b/examples/root/benchmark.cc
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
 

--- a/examples/root/converter.cc
+++ b/examples/root/converter.cc
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    convert(inputFile);

--- a/examples/root/hist2root.cc
+++ b/examples/root/hist2root.cc
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
       sprintf(outputFile,"%s.root",argv[1]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
  
    

--- a/examples/showFile.cc
+++ b/examples/showFile.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    hipo::reader  reader;

--- a/examples/writeEvents.cc
+++ b/examples/writeEvents.cc
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
    char outputFile[256];

--- a/extensions/coda/translate.cc
+++ b/extensions/coda/translate.cc
@@ -48,7 +48,7 @@ int main(int argc, char** argv){
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
     
     //bank.show();

--- a/extensions/dc/cmdparser.hpp
+++ b/extensions/dc/cmdparser.hpp
@@ -336,7 +336,7 @@ namespace cli {
 				args.output << this->usage();
 				//#pragma warning(push)
 				//#pragma warning(disable: 4702)
-				exit(0);
+				exit(1);
 				return false;
 				//#pragma warning(pop)
 			}), "", true);

--- a/extensions/dc/denoise.cc
+++ b/extensions/dc/denoise.cc
@@ -157,7 +157,7 @@ std::cout << std::endl;
  
    /*char inputFile[256];
    if(argc>1) { sprintf(inputFile,"%s",argv[1]);} else {
-      std::cout << " *** please provide a file name..." << std::endl;exit(0);
+      std::cout << " *** please provide a file name..." << std::endl;exit(1);
       }*/
 
    chamber.setRows(112);

--- a/extensions/dc/denoise2.cc
+++ b/extensions/dc/denoise2.cc
@@ -156,7 +156,7 @@ std::cout << std::endl;
  
    /*char inputFile[256];
    if(argc>1) { sprintf(inputFile,"%s",argv[1]);} else {
-      std::cout << " *** please provide a file name..." << std::endl;exit(0);
+      std::cout << " *** please provide a file name..." << std::endl;exit(1);
       }*/
    
    chamber.setRows(112);

--- a/extensions/machine/analyze.cc
+++ b/extensions/machine/analyze.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv){
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
   hipo::reader reader;

--- a/extensions/machine/main.cc
+++ b/extensions/machine/main.cc
@@ -57,7 +57,7 @@ int main(int argc, char** argv){
       //sprintf(outputFile,"%s",argv[2]);
    } else {
       std::cout << " *** please provide a file name..." << std::endl;
-     exit(0);
+     exit(1);
    }
 
   hipo::reader reader;

--- a/hipo4/dictionary.h
+++ b/hipo4/dictionary.h
@@ -156,7 +156,7 @@ class schema {
     schema &getSchema(const char *name){ 
       if(factory.count(name)==0){
         printf("\n\nhipo::dictionary (ERROR) schema {%s} does not exist... exiting\n\n",name);
-           exit(0);
+           exit(1);
       }
       return factory[name];
     }

--- a/hipo4/reader.cpp
+++ b/hipo4/reader.cpp
@@ -291,7 +291,7 @@ std::vector<hipo::bank> reader::getBanks(std::vector<std::string> names){
   
   if(inputStream.is_open()==false){
     printf("\n\nhipo::reader (ERROR) file is not open.... exiting...\n\n");
-    exit(0);
+    exit(1);
   }
   long position = header.headerLength*4;
   hipo::record  dictRecord;
@@ -322,7 +322,7 @@ std::vector<hipo::bank> reader::getBanks(std::vector<std::string> names){
 void  reader::readDictionary(hipo::dictionary &dict){
   if(inputStream.is_open()==false){
     printf("\n\nhipo::reader (ERROR) file is not open.... exiting...\n\n");
-    exit(0);
+    exit(1);
   }
   long position = header.headerLength*4;
   hipo::record  dictRecord;

--- a/hipo4/utils.cpp
+++ b/hipo4/utils.cpp
@@ -119,7 +119,7 @@ namespace hipo {
     file_header.append("   char inputFile[256];\n\n" );
     file_header.append("   if(argc>1) {\n      sprintf(inputFile,\"%s\",argv[1]);\n   } else {\n " );
     file_header.append("     std::cout << \" *** please provide a file name...\" << std::endl;\n" );
-    file_header.append("     exit(0);\n   }\n\n");
+    file_header.append("     exit(1);\n   }\n\n");
     file_header.append("   hipo::reader  reader;\n");
     file_header.append("   reader.open(inputFile);\n\n" );
     return file_header;


### PR DESCRIPTION
Failures should exit with nonzero exit codes. This PR replaces `exit(0)` with `exit(1)`, where appropriate.