### PR TITLE
build: add option for warning (non-)suppression

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -46,7 +46,7 @@ foreach ex : example_sources
       link_with:           project_libs,
       dependencies:        ex.get('deps', []),
       install:             get_option('install_examples'),
-      cpp_args:            [ '-Wno-sign-compare' ], # FIXME: fix the warnings; they are suppressed by these args
+      cpp_args:            get_option('suppress_warnings') ? [ '-Wno-sign-compare' ] : [], # FIXME: fix the warnings; they are suppressed by these args
     )
     if(ex.get('test_this', true))
       test(

--- a/examples/root/meson.build
+++ b/examples/root/meson.build
@@ -14,6 +14,6 @@ foreach ex : example_root_sources
     link_with:           [ hipo_lib ],
     link_args:           [ '-L' + ROOT_libdir, '-lCore', '-lRIO', '-lHist', '-lTree', '-lPhysics' ],
     install:             ex['install_this'],
-    cpp_args:            [ '-Wno-unused-variable', '-Wno-unused-but-set-variable', '-Wno-sign-compare' ], # FIXME: fix the warnings
+    cpp_args:            get_option('suppress_warnings') ? [ '-Wno-unused-variable', '-Wno-unused-but-set-variable', '-Wno-sign-compare' ] : [], # FIXME: fix the warnings
   )
 endforeach

--- a/extensions/dataframes/meson.build
+++ b/extensions/dataframes/meson.build
@@ -43,7 +43,7 @@ dataframe_lib = library(
   link_with:           [ hipo_lib ],
   link_args:           [ '-L' + ROOT_libdir, '-lCore', '-lROOTDataFrame', '-lROOTVecOps' ],
   build_rpath:         ROOT_libdir,
-  cpp_args:            [ '-Wno-sign-compare' ], # FIXME: fix these warnings
+  cpp_args:            get_option('suppress_warnings') ? [ '-Wno-sign-compare' ] : [], # FIXME: fix these warnings
   install: true
 )
 install_headers(dataframe_headers, subdir: meson.project_name())

--- a/hipo4/meson.build
+++ b/hipo4/meson.build
@@ -41,14 +41,14 @@ hipo_lib = library(
   meson.project_name(),
   hipo_sources,
   dependencies: [ lz4_dep ],
-  cpp_args: [ # FIXME: fix the warnings; they are suppressed by these args
+  cpp_args: get_option('suppress_warnings') ? [ # FIXME: fix the warnings; they are suppressed by these args
     '-Wno-sign-compare',
     '-Wno-unused-variable',
     '-Wno-unused-but-set-variable',
     '-Wno-misleading-indentation',
     '-Wno-format',
     '-Wno-stringop-overflow',
-    ],
+    ] : [],
   install: true
 )
 

--- a/meson.options
+++ b/meson.options
@@ -1,3 +1,6 @@
+# compiling
+option('suppress_warnings', type: 'boolean', value: true, description: 'if true, suppress compiler warnings; this option exists until warnings are fixed')
+
 # examples
 option('build_examples',   type: 'boolean', value: true,  description: 'build examples; see also "install_examples"')
 option('install_examples', type: 'boolean', value: false, description: 'install examples; requires "build_examples" to be true')


### PR DESCRIPTION
Adds build option `suppress_warnings` to control whether compilation warnings are suppressed (_cf. #61). They are suppressed by default (`suppress_warnings = true`).

To control this option, run the following commands (while in the **build** directory):
```bash
meson configure -D suppress_warnings=false       # disable warning suppression
meson configure -D suppress_warnings=true        # enable warning suppression
```
Then the warnings will be suppressed or not, for the next time you run `ninja`.