### PR TITLE
fix: unknown warning option '-Wno-stringop-overflow' from `clang++`

### DIFF
--- a/hipo4/meson.build
+++ b/hipo4/meson.build
@@ -47,7 +47,7 @@ hipo_lib = library(
     '-Wno-unused-but-set-variable',
     '-Wno-misleading-indentation',
     '-Wno-format',
-    '-Wno-stringop-overflow',
+    '-Wno-shift-overflow',
     ],
   install: true
 )


### PR DESCRIPTION
resolves #60 