### PR TITLE
Update RHipoDS.cxx

### DIFF
--- a/extensions/dataframes/RHipoDS.cxx
+++ b/extensions/dataframes/RHipoDS.cxx
@@ -82,7 +82,7 @@ RHipoDS::RHipoDS(const std::vector<std::string> &files, int nevt_inspect, int de
       AddFiles(file_name);
    }
    Init(nevt_inspect);
-   std::cout<<" RHipoDS::RHipoDS "<<files.size()<<" "<<nevt_inspect<<" "<<fHipoFiles.size()<<" "<<GetNFiles()<<std::endl;
+  
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Remove rougue cout statement with undefined function GetNFiles. For some reason it still compiled on some systems, function must be defined in some version headers